### PR TITLE
Ensure 'pgbouncer' reloads service on change

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name          '3dna-pgbouncer'
-version       '0.1.0'
+version       '0.1.1'
 source        'https://github.com/3dna/3dna-pgbouncer/'
 author        '3dna'
 license       'BSD-3'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -10,5 +10,6 @@ class pgbouncer::service inherits pgbouncer {
     enable     => true,
     hasstatus  => true,
     hasrestart => true,
+    restart    => "/usr/sbin/service ${::pgbouncer::service_name} reload",
   }
 }


### PR DESCRIPTION
This PR updates the `pgbouncer` module to reload config as opposed to restart. This is to ensure that any changes to the module reflected in https://github.com/3dna/puppet/pull/220 do not take down production as changes are introduced.